### PR TITLE
fix support for newer CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.6...4.1)
 project(ALEditor)
 
 include_directories(
@@ -46,8 +46,17 @@ add_library(ale SHARED
 )
 
 add_executable(ALEditor ALEditor.cpp)
-ADD_CUSTOM_COMMAND(TARGET ALEditor COMMAND rc -o ALEditor.rsrc ${CMAKE_CURRENT_SOURCE_DIR}/res/ALEditor.rdef COMMENT "Compiling resources")
-ADD_CUSTOM_COMMAND(TARGET ALEditor COMMAND xres -o ALEditor ALEditor.rsrc COMMENT "Adding resources to executable")
-ADD_CUSTOM_COMMAND(TARGET ALEditor COMMAND mimeset --all ALEditor COMMENT "Adjusting MIME types")
+ADD_CUSTOM_COMMAND(TARGET ALEditor POST_BUILD
+	COMMAND rc -o ALEditor.rsrc ${CMAKE_CURRENT_SOURCE_DIR}/res/ALEditor.rdef
+	COMMENT "Compiling resources"
+)
+ADD_CUSTOM_COMMAND(TARGET ALEditor POST_BUILD
+	COMMAND xres -o ALEditor ALEditor.rsrc
+	COMMENT "Adding resources to executable"
+)
+ADD_CUSTOM_COMMAND(TARGET ALEditor POST_BUILD
+	COMMAND mimeset --all ALEditor
+	COMMENT "Adjusting MIME types"
+)
 
 target_link_libraries(ALEditor ${CORELIBS} be alm tracker ale)


### PR DESCRIPTION
CMake >= 4.0 requires a compatibility switch if the project doesn't declare support for versions >= 3.5.

Add the `POST_BUILD` keyword to the `add_custom_command` calls, which is required by a new cmake policy since version 3.31.

Now we can declare that we support all new policies up to the current version 4.1.